### PR TITLE
DCP-3675: update button link styles

### DIFF
--- a/sass/components/_normalize.scss
+++ b/sass/components/_normalize.scss
@@ -55,7 +55,7 @@ button {
   border: 0;
   background: transparent;
   line-height: 1;
-  cursor:  auto;
+  cursor:  pointer;
 }
 
 // Prevent text overflow on pre

--- a/sass/mixins/_links.scss
+++ b/sass/mixins/_links.scss
@@ -15,7 +15,8 @@
   font-weight: key($link-conf, font-weight);
   text-decoration: none;
   border-bottom: 1px solid key($link-conf, color);
-  line-height: 1.25rem;
+  letter-spacing: inherit;
+  line-height: 1;
 
   @include selectors(active) {
     color: key($link-conf, active-color);


### PR DESCRIPTION
Most of our modals now use button tags for accessibility. This covers styling updates to make the button tags look and function like a tags if they are using the Text link style.