### PR TITLE
DCP-4084: add temporary color classes

### DIFF
--- a/sass/components/_color.scss
+++ b/sass/components/_color.scss
@@ -31,6 +31,7 @@
   background-color: var(--color-brand-promo-alt);
 }
 
+// @deprecated
 // The following Badge Type terms inside the Badges taxonomy are deprecated.
 // - Blue Promotion, Purple Promotion, Feature
 // @todo: Remove these styles once there are no more taxonomy terms with this Badge Type.

--- a/sass/components/_color.scss
+++ b/sass/components/_color.scss
@@ -30,3 +30,16 @@
 .color-brand-bg-promo-alt {
   background-color: var(--color-brand-promo-alt);
 }
+
+// The following Badge Type terms inside the Badges taxonomy are deprecated.
+// - Blue Promotion, Purple Promotion, Feature
+// @todo: Remove these styles once there are no more taxonomy terms with this Badge Type.
+.color-brand-bg-blue-promotion {
+  background-color: var(--color-brand-orchid);
+}
+.color-brand-bg-purple-promotion {
+  background-color: var(--color-brand-lavender-100);
+}
+.color-brand-bg-feature {
+  background-color: var(--color-brand-sandman);
+}


### PR DESCRIPTION
Add temporary color classes to not break prod. The Badges taxonomy now uses the color-brand-bg-{name} to set the bg color. So the colors need to exist in the style library. There is a tech debt ticket being created to come back and remove once SM changes the Badges to use the new names instead of these deprecated ones