### PR TITLE
Feature/ DCP-4399 Hide Clover Footer on Checkout

### DIFF
--- a/sass/components/_normalize.scss
+++ b/sass/components/_normalize.scss
@@ -97,3 +97,8 @@ blockquote {
   max-width: initial;
   max-height: initial;
 }
+
+// Clover Footer in Checkout
+.clover-footer {
+  display: none !important;
+}


### PR DESCRIPTION
- added a global style to hide the clover-footer if it is visible (should only be visible on checkout) so we don't target the document from the react bundle.

Notes: We are not rendering the clover footer ourselves, but they did expose the footer with a class name.