### PR TITLE
CSE-548: squelch CSS warnings from SASS

### DIFF
--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -53,9 +53,9 @@ $color-map: (
         promo-alt: #395542, // holiday promo
         eclipse: #2E1A4D, // holiday color
         petal: #FFC3D1,
-        lime: #E5F935, // holiday color
-        violet: #5436CC,
-        yellow: #FFCD6F,
+        'lime': #E5F935, // holiday color
+        'violet': #5436CC,
+        'yellow': #FFCD6F,
         dark-navy: #0F0F3A,
         daydream-light: #FEE5FF,
         mist-30: #E7E6F7,


### PR DESCRIPTION
Identifiers that are CSS colors must be quoted.