### PR TITLE
New white shade added to the library (and style guide)

### DIFF
--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -91,6 +91,7 @@ $color-map: (
   --color-brand-whitefade-45: rgb(var(--color-brand-white-rgb) / 45%);
   --color-brand-whitefade-50: rgb(var(--color-brand-white-rgb) / 50%);
   --color-brand-whitefade-60: rgb(var(--color-brand-white-rgb) / 60%);
+  --color-brand-whitefade-80: rgb(var(--color-brand-white-rgb) / 80%);
   --color-brand-primary-rgb: 24 24 49;
   --color-brand-primaryfade-30: rgb(var(--color-brand-primary-rgb) / 30%);
   --color-brand-primaryfade-80: rgb(var(--color-brand-primary-rgb) / 80%);


### PR DESCRIPTION
- Added `--color-brand-whitefade-80` CSS variable to the `$color-map` for an 80% opacity white fade.