### PR TITLE
CSE-3: Fix inline text link styles applying to embedded paragraph button styles on blog pages

### DIFF
--- a/sass/components/_typography.scss
+++ b/sass/components/_typography.scss
@@ -275,7 +275,7 @@ sup {
     margin-bottom: 0;
   }
 
-  // Inline CTAs
+  // Inline text links - don't target <a> tags inside embedded .paragraphs.
   a:not(.paragraph a) {
     @include link(primary, sm, medium);
     font-size: inherit;

--- a/sass/components/_typography.scss
+++ b/sass/components/_typography.scss
@@ -275,9 +275,9 @@ sup {
     margin-bottom: 0;
   }
 
-  a {
+  // Inline CTAs
+  a:not(.paragraph a) {
     @include link(primary, sm, medium);
-    
     font-size: inherit;
   }
 


### PR DESCRIPTION
Blog pages have a body field that allows embedded paragraphs to be inserted into the text editor. They contain CTAs which we want rendered as buttons. But the body field also allows inline text links. The current styles `.text-formatted a` is applying to all `<a>` tags. We need this to just apply to inline text links (i.e. `<a>` tags not wrapped inside a paragraph)

We only allow embedded paragraphs in the blog page text editor, so this change will only affect blog pages (which is what we want)